### PR TITLE
Propose explicit style: first argument on its own line

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -436,6 +436,29 @@ result = get_things(
 )
 ```
 
+### First thing on its own line
+
+Any statement being split across multiple lines **should** move the first *thing*
+to the next line, indented one deeper than the previous line.  For example, changes
+to function names **should not** change indentation level of all arguments. Reading
+the diff is faster and less error prone when only important lines change.
+
+```python
+# should
+result = get_things(
+    argument_a,
+    argument_b,
+    argument_c,
+    argument_d,
+)
+
+# should not
+result = get_things(argument_a,
+                    argument_b,
+                    argument_c,
+                    argument_d,
+                    )
+```
 
 ### Closing parenthesis/bracket/brace
 


### PR DESCRIPTION
It irks me when you have to reset the whitespace on all the arguments of a multiline function call, just because you changed the name of a function or returned value.

This pattern is already prevalent across the repositories, but was never explicitly listed as a preferred style. It would feel more natural to call out silly style things like this in PRs if they were part of the style guide.